### PR TITLE
Use https

### DIFF
--- a/scripts/20200210-112152.sql
+++ b/scripts/20200210-112152.sql
@@ -1,0 +1,3 @@
+update resolvers
+set uri = replace(uri, 'http://', 'https://')
+where visibility = 'public';


### PR DESCRIPTION
The main resolvers deny access over http, so tests are failing