### PR TITLE
FDN-3571: make install.sh faster & remove unused function

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,6 @@ then
 	psql -q -U postgres -d postgres -c "GRANT ALL ON DATABASE $DBNAME TO api"
 	psql -q -U postgres -d $DBNAME -f $DBNAME.schema.sql
 	psql -q -U postgres -d $DBNAME -f $DBNAME.data.sql
-	psql -q -U api -d $DBNAME -c 'SELECT partman5.run_maintenance()'
 fi
 
 sem-apply --url postgresql://api@localhost/$DBNAME

--- a/scripts/20250514-083620.sql
+++ b/scripts/20250514-083620.sql
@@ -1,0 +1,2 @@
+DROP FUNCTION IF EXISTS journal.refresh_journaling;
+ALTER FUNCTION journal.refresh_journaling_native RENAME TO refresh_journaling;


### PR DESCRIPTION
The first change removes the `run_maintenance` step in `install.sh`.
That step is time consuming, memory consuming, more so as time goes
by. Eventually it will hit limits (e.g., number of locks acquired)
and fail. It happened in some repository already, and this step has
been removed there as a consequence. It is also an unnecessary step,
so we remove it.

Secondly, the `refresh_journaling` is a function that just delegates
to the `_native` variant, the only one possible these days. So in
this PR we swap them around and get rid of the wrapper.

```
db=> \sf journal.refresh_journaling
CREATE OR REPLACE FUNCTION journal.refresh_journaling(p_source_schema_name character varying, p_source_table_name character varying, p_target_schema_name character varying, p_target_table_name character varying)
 RETURNS character varying
 LANGUAGE plpgsql
AS $function$
BEGIN
  RETURN journal.refresh_journaling_native(p_source_schema_name, p_source_table_name, p_target_schema_name, p_target_table_name);
END;
$function$
```
